### PR TITLE
Fix failing build and update Log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<!-- the patty version for Maven Java src resources -->
 		<patty.version>0.0.1</patty.version>
 		<junit.version>4.13.1</junit.version>
-		<log4j.version>2.15.0</log4j.version>
+		<log4j.version>2.17.1</log4j.version>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 		<repository>
 			<id>CogCompSoftware</id>
 			<name>CogCompSoftware</name>
-			<url>http://cogcomp.org/m2repo/</url>
+			<url>https://cogcomp.cs.illinois.edu/m2repo/</url>
 		</repository>
 	</repositories>
 

--- a/repository/org/aksw/AGDISTIS/0.4.0/AGDISTIS-0.4.0.pom
+++ b/repository/org/aksw/AGDISTIS/0.4.0/AGDISTIS-0.4.0.pom
@@ -81,22 +81,22 @@
         <repository>
             <id>maven-restlet</id>
             <name>Public online Restlet repository</name>
-            <url>http://maven.restlet.org</url>
+            <url>https://maven.restlet.org</url>
         </repository>
         <repository>
             <id>Apache Repo Central</id>
             <name>Apache Repository</name>
-            <url>http://repo.maven.apache.org/maven2</url>
+            <url>https://repo.maven.apache.org/maven2</url>
         </repository>
         <repository>
             <id>maven.aksw.internal</id>
             <name>University Leipzig, AKSW Maven2 Repository</name>
-            <url>http://maven.aksw.org/archiva/repository/internal</url>
+            <url>https://maven.aksw.org/archiva/repository/internal</url>
         </repository>
         <repository>
             <id>maven.aksw.snapshots</id>
             <name>University Leipzig, AKSW Maven2 Repository</name>
-            <url>http://maven.aksw.org/archiva/repository/snapshots</url>
+            <url>https://maven.aksw.org/archiva/repository/snapshots</url>
         </repository>
     </repositories>
     <dependencies>

--- a/repository/org/aksw/gerbil.nif.transfer/1.2.6-jena3.1-SNAPSHOT/gerbil.nif.transfer-1.2.6-jena3.1-SNAPSHOT.pom
+++ b/repository/org/aksw/gerbil.nif.transfer/1.2.6-jena3.1-SNAPSHOT/gerbil.nif.transfer-1.2.6-jena3.1-SNAPSHOT.pom
@@ -37,12 +37,12 @@
 		<repository>
 			<id>maven.aksw.internal</id>
 			<name>University Leipzig, AKSW Maven2 Repository</name>
-			<url>http://maven.aksw.org/repository/internal</url>
+			<url>https://maven.aksw.org/repository/internal</url>
 		</repository>
 		<repository>
 			<id>maven.aksw.snapshots</id>
 			<name>University Leipzig, AKSW Maven2 Repository</name>
-			<url>http://maven.aksw.org/repository/snapshots</url>
+			<url>https://maven.aksw.org/repository/snapshots</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
This pull request fixes the build failure (one of the used maven repositories moved and plain http connections are no longer allowed by maven) and updates the Log4j version to fix several security issues (see: https://logging.apache.org/log4j/2.x/security.html).